### PR TITLE
Fixes listen iface argument for http_webdav and logging output

### DIFF
--- a/cmd/xtproxy/main.go
+++ b/cmd/xtproxy/main.go
@@ -172,13 +172,10 @@ func mainServe(args []string) error {
 			opts = append(opts, xtproxy.WithTFTPAddr(udpaddr))
 		case httpPort:
 			tcpaddr := net.TCPAddrFromAddrPort(addrport)
-			opts = append(opts, xtproxy.WithHTTPAddr(tcpaddr))
+			opts = append(opts, xtproxy.WithHTTPWebdavAddr(tcpaddr, webdavHandle))
 		default:
 			return fmt.Errorf("unknown port %d: %s", int(addrport.Port()), errUsage)
 		}
-	}
-	if webdavHandle != "" {
-		opts = append(opts, xtproxy.WithWebdavHandle(webdavHandle))
 	}
 	fproxy, err := xtproxy.NewXTProxy(opts...)
 	if err != nil {

--- a/cmd/xtproxy/main.go
+++ b/cmd/xtproxy/main.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/azryve/xtproxy/pkg/xtproxy"
@@ -112,6 +113,9 @@ func setupListenAddrs() ([]netip.AddrPort, error) {
 			listenaddrs = append(listenaddrs, netip.AddrPortFrom(ip, uint16(httpPort)))
 		}
 	}
+	listenaddrs = slices.DeleteFunc(listenaddrs, func(addr netip.AddrPort) bool {
+		return addr.Port() == 0
+	})
 	return listenaddrs, nil
 }
 

--- a/pkg/xtproxy/xtproxy.go
+++ b/pkg/xtproxy/xtproxy.go
@@ -16,7 +16,6 @@ type waiter interface {
 type XTProxy struct {
 	mountfs *aferomount.MountFs
 	waiters []waiter
-	http    *XTProxyHTTPWebdav
 }
 type XTProxyOpt func(m *XTProxy) error
 
@@ -60,27 +59,24 @@ func WithTFTPAddr(addr *net.UDPAddr) XTProxyOpt {
 	}
 }
 
-func WithHTTPAddr(addr *net.TCPAddr) XTProxyOpt {
+func WithHTTPWebdavAddr(addr *net.TCPAddr, webdavHandle string) XTProxyOpt {
 	return func(m *XTProxy) error {
 		listener, err := net.ListenTCP("tcp", addr)
 		if err != nil {
 			return err
 		}
-		if m.http == nil {
-			m.http = &XTProxyHTTPWebdav{Fs: m.mountfs}
-		}
-		m.http.Listener = listener
-		m.waiters = append(m.waiters, m.http)
-		return nil
+		return WithHTTPWebdavListener(listener, webdavHandle)(m)
 	}
 }
 
-func WithWebdavHandle(webdavHandle string) XTProxyOpt {
+func WithHTTPWebdavListener(listener *net.TCPListener, webdavHandle string) XTProxyOpt {
 	return func(m *XTProxy) error {
-		if m.http == nil {
-			m.http = &XTProxyHTTPWebdav{Fs: m.mountfs}
+		http := &XTProxyHTTPWebdav{
+			Fs:           m.mountfs,
+			WebdavHandle: webdavHandle,
+			Listener:     listener,
 		}
-		m.http.WebdavHandle = webdavHandle
+		m.waiters = append(m.waiters, http)
 		return nil
 	}
 }

--- a/pkg/xtproxy/xtproxy_test.go
+++ b/pkg/xtproxy/xtproxy_test.go
@@ -101,12 +101,13 @@ func TestHTTPToWebdav(t *testing.T) {
 func xtproxyHttpProxyForTest(t *testing.T, fs afero.Fs, webdavHandle string) (*XTProxy, net.Addr) {
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	assert.NoError(t, err)
+	l, err := net.ListenTCP("tcp", addr)
+	assert.NoError(t, err)
 
 	xt, err := NewXTProxy(
-		WithHTTPAddr(addr),
-		WithWebdavHandle(webdavHandle),
+		WithHTTPWebdavListener(l, webdavHandle),
 		WithMount(fs, "/"),
 	)
 	assert.NoError(t, err)
-	return xt, xt.http.Listener.Addr()
+	return xt, l.Addr()
 }


### PR DESCRIPTION
All listeners except the last one was non-functional.
This is due to making http a singleton which was a hack in the first place.

Also remove disabled ports from listen addr to show only activated listeners.